### PR TITLE
Update the fixupimages

### DIFF
--- a/specifyweb/frontend/js_src/lib/reports.js
+++ b/specifyweb/frontend/js_src/lib/reports.js
@@ -416,7 +416,7 @@ function fixupImages(reportXML) {
     $('imageExpression', reportDOM).each(function() {
         var imageExpression = $(this).text();
         if (imageExpression.match(/^it\.businesslogic\.ireport\.barcode\.BcImage\.getBarcodeImage/)) return;
-        if (imageExpression.match(/^new\s*java\.net\.URL\s*\(\s*("|')http(s:||)\/\//)) return;
+        if (imageExpression.match(/^new\s*java\.net\.URL\s*\(\s*("|')http(s:|:)\/\//)) return;
         var match = imageExpression.match(/\$P\{\s*RPT_IMAGE_DIR\s*\}\s*\+\s*"\/"\s*\+\s*"(.*?)"/);
         if (!match) {
             badImageExpressions.push(imageExpression);


### PR DESCRIPTION
Adjust image expression validation for "new java.net.URL" to deal with http and https and for when  use single or double quotes.
This is a second request that correct the a minor error from last pull request. 
Could just ignore the first pull request.